### PR TITLE
fix: trim external GA path config

### DIFF
--- a/core/src/runner_commands.rs
+++ b/core/src/runner_commands.rs
@@ -47,7 +47,7 @@ use crate::runner_manager::{
 };
 use crate::{credential_store, managed_model_config, managed_prompt, managed_runtime};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tauri::{AppHandle, Emitter, State};
 use tokio::sync::broadcast::error::RecvError;
@@ -315,7 +315,17 @@ fn prepare_external_spawn_args(
     Ok(args)
 }
 
-fn normalize_external_ga_path(raw: &PathBuf) -> Result<PathBuf, RunnerSpawnError> {
+pub(crate) fn normalize_external_ga_path(raw: &PathBuf) -> Result<PathBuf, RunnerSpawnError> {
+    normalize_external_ga_path_with_home(
+        raw,
+        directories::BaseDirs::new().map(|dirs| dirs.home_dir().to_path_buf()),
+    )
+}
+
+fn normalize_external_ga_path_with_home(
+    raw: &PathBuf,
+    home_dir: Option<PathBuf>,
+) -> Result<PathBuf, RunnerSpawnError> {
     let raw = raw.to_str().ok_or_else(|| RunnerSpawnError::PathEncoding {
         detail: format!("ga_path not UTF-8: {}", raw.display()),
     })?;
@@ -325,13 +335,28 @@ fn normalize_external_ga_path(raw: &PathBuf) -> Result<PathBuf, RunnerSpawnError
             detail: "ga_path is empty".into(),
         });
     }
-    let path = PathBuf::from(trimmed);
+    let path = expand_home_relative_path(trimmed, home_dir.as_deref())
+        .unwrap_or_else(|| PathBuf::from(trimmed));
     if !path.is_dir() {
         return Err(RunnerSpawnError::GaPathInvalid {
             detail: format!("not a directory: {}", path.display()),
         });
     }
     Ok(path)
+}
+
+fn expand_home_relative_path(raw: &str, home_dir: Option<&Path>) -> Option<PathBuf> {
+    let suffix = match raw {
+        "~" => "",
+        s if s.starts_with("~/") || s.starts_with("~\\") => &s[2..],
+        _ => return None,
+    };
+    let home = home_dir?;
+    if suffix.is_empty() {
+        Some(home.to_path_buf())
+    } else {
+        Some(home.join(suffix))
+    }
 }
 
 #[tauri::command]
@@ -563,6 +588,32 @@ mod tests {
             Err(other) => panic!("expected GaPathInvalid, got {}", other),
             Ok(_) => panic!("expected error, got Ok"),
         }
+    }
+
+    #[test]
+    fn external_ga_path_normalization_expands_home_relative_paths() {
+        let home = tempfile::TempDir::new().expect("home tempdir");
+        let dir = home.path().join("GenericAgent");
+        std::fs::create_dir(&dir).expect("ga dir");
+        let normalized = normalize_external_ga_path_with_home(
+            &PathBuf::from(" ~/GenericAgent "),
+            Some(home.path().to_path_buf()),
+        )
+        .expect("normalize");
+        assert_eq!(normalized, dir);
+    }
+
+    #[test]
+    fn external_ga_path_normalization_expands_windows_style_home_relative_paths() {
+        let home = tempfile::TempDir::new().expect("home tempdir");
+        let dir = home.path().join("GenericAgent");
+        std::fs::create_dir(&dir).expect("ga dir");
+        let normalized = normalize_external_ga_path_with_home(
+            &PathBuf::from(" ~\\GenericAgent "),
+            Some(home.path().to_path_buf()),
+        )
+        .expect("normalize");
+        assert_eq!(normalized, dir);
     }
 
     #[test]

--- a/core/src/runner_commands.rs
+++ b/core/src/runner_commands.rs
@@ -301,6 +301,8 @@ fn prepare_external_spawn_args(
     mut args: SpawnArgs,
     app: &AppHandle,
 ) -> Result<SpawnArgs, RunnerSpawnError> {
+    args.ga_path = normalize_external_ga_path(&args.ga_path)?;
+
     // bridgeCwd is Galley's implementation detail, not user GA state.
     // Dev should run from the repo root; production should run from the
     // packaged resources dir. Ignore stale persisted bridgeCwd values such as
@@ -311,6 +313,25 @@ fn prepare_external_spawn_args(
         }
     })?;
     Ok(args)
+}
+
+fn normalize_external_ga_path(raw: &PathBuf) -> Result<PathBuf, RunnerSpawnError> {
+    let raw = raw.to_str().ok_or_else(|| RunnerSpawnError::PathEncoding {
+        detail: format!("ga_path not UTF-8: {}", raw.display()),
+    })?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(RunnerSpawnError::GaPathInvalid {
+            detail: "ga_path is empty".into(),
+        });
+    }
+    let path = PathBuf::from(trimmed);
+    if !path.is_dir() {
+        return Err(RunnerSpawnError::GaPathInvalid {
+            detail: format!("not a directory: {}", path.display()),
+        });
+    }
+    Ok(path)
 }
 
 #[tauri::command]
@@ -523,6 +544,25 @@ mod tests {
         assert!(parsed.runtime_kind.is_none());
         assert!(parsed.env.is_empty());
         assert!(parsed.active_session_id.is_none());
+    }
+
+    #[test]
+    fn external_ga_path_normalization_trims_pasted_whitespace() {
+        let dir = tempfile::TempDir::new().expect("tempdir");
+        let raw = PathBuf::from(format!(" {} ", dir.path().display()));
+        let normalized = normalize_external_ga_path(&raw).expect("normalize");
+        assert_eq!(normalized, dir.path());
+    }
+
+    #[test]
+    fn external_ga_path_normalization_rejects_empty_after_trim() {
+        match normalize_external_ga_path(&PathBuf::from("  ")) {
+            Err(RunnerSpawnError::GaPathInvalid { detail }) => {
+                assert_eq!(detail, "ga_path is empty");
+            }
+            Err(other) => panic!("expected GaPathInvalid, got {}", other),
+            Ok(_) => panic!("expected error, got Ok"),
+        }
     }
 
     #[test]

--- a/core/src/socket_listener.rs
+++ b/core/src/socket_listener.rs
@@ -61,7 +61,9 @@ use crate::api::{
 use crate::db::SqliteGalley;
 use crate::ipc::{IpcCommand, SetLlmCommand, UserMessageCommand};
 use crate::managed_runtime;
-use crate::runner_commands::{prepare_managed_spawn_args, spawn_emit_task};
+use crate::runner_commands::{
+    normalize_external_ga_path, prepare_managed_spawn_args, spawn_emit_task,
+};
 use crate::runner_manager::{
     BroadcastItem, RunnerManager, RunnerSpawnError, SendCommandError, SpawnArgs,
 };
@@ -868,14 +870,11 @@ async fn spawn_args_for_session_new(
     let config: GaConfigPref = serde_json::from_value(raw).map_err(|e| {
         SocketResponseLite::runner_error(format!("ga_config pref shape mismatch: {e}"))
     })?;
-    let ga_path = non_empty_pref(config.ga_path.as_deref(), "gaPath")?;
-    let ga_path = PathBuf::from(ga_path);
-    if !ga_path.is_dir() {
-        return Err(SocketResponseLite::runner_error(format!(
-            "GA path invalid: not a directory: {}",
-            ga_path.display()
-        )));
-    }
+    let ga_path = normalize_external_ga_path(&PathBuf::from(non_empty_pref(
+        config.ga_path.as_deref(),
+        "gaPath",
+    )?))
+    .map_err(SocketResponseLite::runner_spawn_error)?;
 
     let bridge_cwd = resolve_bridge_cwd(&config, app)?;
     let python = resolve_python_for_socket(&config, app)?;

--- a/gui/src/stores/prefs.ts
+++ b/gui/src/stores/prefs.ts
@@ -179,6 +179,15 @@ interface PrefsActions {
 
 export type PrefsStore = PrefsState & PrefsActions;
 
+function normalizeGAConfig(config: GAConfig): GAConfig {
+  return {
+    ...config,
+    python: config.python.trim(),
+    gaPath: config.gaPath.trim(),
+    bridgeCwd: config.bridgeCwd.trim(),
+  };
+}
+
 export const usePrefsStore = create<PrefsStore>((set, get) => ({
   // ---- Initial state (demo fixtures until hydratePrefs) ----
   gaConfig: DEFAULT_GA_CONFIG,
@@ -277,7 +286,7 @@ export const usePrefsStore = create<PrefsStore>((set, get) => ({
 
   // ---- GA config ----
   setGAConfig: async (partial) => {
-    const merged = { ...get().gaConfig, ...partial };
+    const merged = normalizeGAConfig({ ...get().gaConfig, ...partial });
     // Translate the python alias (Tauri shell-capability `name` like
     // "python-framework-3-14") to its resolved display path for the
     // Settings → Runtime "Python" field. Falls back to the raw alias
@@ -408,19 +417,19 @@ export const usePrefsStore = create<PrefsStore>((set, get) => ({
       }>("ga_config");
       if (saved && saved.gaPath) {
         hasGAConfig = true;
-        const displayCandidate = await findCandidateByAlias(saved.python);
-        const pythonDisplay = displayCandidate?.displayPath ?? saved.python;
         // Migrate legacy alpha.2 configs (no useExternalPython field).
         // Default to false so upgrading users automatically pick up
         // the bundled Python — they keep their old `python` alias on
         // file as the escape hatch if anything goes sideways.
-        const migrated: GAConfig = {
+        const migrated = normalizeGAConfig({
           ...saved,
           useExternalPython: saved.useExternalPython ?? false,
-        };
+        });
+        const displayCandidate = await findCandidateByAlias(migrated.python);
+        const pythonDisplay = displayCandidate?.displayPath ?? migrated.python;
         set({ gaConfig: migrated });
         useRuntimeStore.getState().patchRuntimeInfo({
-          gaPath: saved.gaPath,
+          gaPath: migrated.gaPath,
           pythonVersion: pythonDisplay,
         });
       }


### PR DESCRIPTION
Fixes #3.

## Summary

- Trim `ga_config` path-like fields before saving or hydrating prefs so pasted leading/trailing whitespace does not survive into runtime state.
- Defensively normalize external GA paths in the Rust runner spawn path before passing `--ga-path` to the Python bridge.
- Add Rust unit coverage for trimming a whitespace-wrapped existing directory and rejecting an empty-after-trim path.

## Why

The onboarding/settings health-check path validation trims the typed path before checking the filesystem. That allowed a whitespace-padded pasted path to appear healthy while the saved/spawned value still contained the leading space, causing Python to resolve it as a relative path under Galley's runner cwd.

## Verification

- `corepack pnpm@10.33.1 --dir gui typecheck`
- `corepack pnpm@10.33.1 --dir gui lint`
- `git diff --check`

Not run here: `cargo test` / `cargo check` because this Windows machine does not have `cargo` installed or on PATH.