### PR TITLE
fix(conductor): install managed mykey loader in IM-spawned conductor

### DIFF
--- a/managed-ga/code/frontends/conductor.py
+++ b/managed-ga/code/frontends/conductor.py
@@ -26,6 +26,43 @@ def _resolve_ga_root() -> str:
 ROOT = _resolve_ga_root()
 if ROOT not in sys.path: sys.path.insert(0, ROOT)
 
+
+def _install_managed_mykey_loader() -> None:
+    """Propagate the managed-runtime mykey loader into this child process.
+
+    Under the Galley managed runtime, ``runner.managed_runtime.install_
+    managed_mykey_loader()`` is only called in supervisor processes. The
+    conductor is spawned as a separate child process by IM frontends
+    (``_start_conductor`` in wechatapp/qqapp/...), so llmcore never learns
+    about the Galley-owned model config: GenericAgent.__init__ resolves zero
+    llmclients, ``llmclient`` stays None, and the agent loop dies silently on
+    the first incoming message -- the bot receives messages but can never
+    reply.
+    """
+    if not (os.environ.get("GALLEY_MANAGED_MODEL_CONFIG_JSON")
+            or os.environ.get("GALLEY_MANAGED_MODEL_CONFIG_PATH")):
+        return  # not running under the Galley managed runtime
+    here = os.path.dirname(os.path.abspath(__file__))
+    cand = here
+    for _ in range(6):  # repo checkout: <root>/runner; bundled app: <Resources>/runner
+        nxt = os.path.dirname(cand)
+        if nxt == cand:
+            break
+        cand = nxt
+        if os.path.isfile(os.path.join(cand, "runner", "managed_runtime.py")):
+            if cand not in sys.path:
+                sys.path.insert(0, cand)
+            break
+    try:
+        from runner.managed_runtime import install_managed_mykey_loader
+        install_managed_mykey_loader()
+        print("[conductor] managed mykey loader installed")
+    except Exception as exc:  # never block conductor startup over this
+        print(f"[conductor] managed mykey loader skipped: {exc}")
+
+
+_install_managed_mykey_loader()
+
 from agentmain import GenericAgent
 
 HOST = "127.0.0.1"


### PR DESCRIPTION
# fix(conductor): install managed mykey loader in IM-spawned conductor

## Problem

Under the Galley managed runtime, WeChat (and other IM frontends) receive
messages fine but the conductor **never replies**. Timeline observed on
macOS (Galley 0.4.10):

1. IM frontend spawns conductor via `_start_conductor()` -> uvicorn on :8900 comes up.
2. Frontend POSTs the incoming message to `POST /chat`, conductor enqueues it.
3. `Conductor.start()` -> `GenericAgent.__init__` -> `load_llm_sessions()` finds
   **zero** LLM clients (`llmclient = None`).
4. The runner loop dies silently on the first task -> no assistant item is ever
   added, no reply is ever sent.

Verified via the conductor `WS /ws` handshake: `llms count: 0`,
`token-stats: {"records": []}` — the LLM is never called.

## Root cause

`runner/managed_runtime.py::install_managed_mykey_loader()` — which patches
`llmcore._load_mykeys` to read Galley-owned model config
(`GALLEY_MANAGED_MODEL_CONFIG_JSON` / `GALLEY_MANAGED_MODEL_CONFIG_PATH`) — is
installed **only in supervisor processes** (4 call sites in
`managed_im_supervisor.py`). The conductor is a *separate child process*
spawned by IM frontends, so it never gets the loader. In that child,
`llmcore.reload_mykeys()` falls back to looking for `mykey.py` / `mykey.json`
next to llmcore, finds none, swallows the error (`except: pass`), and every
model is invisible.

## Fix

Install the same loader at conductor startup, before `import agentmain`,
guarded so it is a no-op outside the managed runtime (env marker check) and
layout-agnostic (walks up to locate the `runner` package: works both in a repo
checkout (`<root>/runner`) and in the packaged app (`<Resources>/runner`)).

## Testing

- macOS, Galley 0.4.10 managed runtime, WeChat channel:
  - Before: `WS /ws` -> `llms count: 0`; incoming message produced no reply.
  - After: `WS /ws` -> `llms count: 8`; incoming "你好" was answered
    end-to-end in ~16s (two LLM hops, conductor -> reply POSTed to /chat ->
    delivered to WeChat).
- `py_compile` clean on the patched file.

## Notes

- A related crash in `wechatapp._start_conductor()` (Windows-only
  `DETACHED_PROCESS` evaluated on macOS) was already fixed upstream in 69e3c0d;
  this PR covers the remaining loader gap.
